### PR TITLE
DM-23651: ap_pipe calls some deprecated things

### DIFF
--- a/data/config/processCcd.py
+++ b/data/config/processCcd.py
@@ -19,9 +19,6 @@ config.isr.doFringe=False
 # Apply correction for CCD defects, e.g. hot pixels?
 config.isr.doDefect=True
 
-# Apply a distortion model based on camera geometry to the WCS?
-config.isr.doAddDistortionModel=True
-
 # Persist postISRCCD?
 config.isr.doWrite=False
 


### PR DESCRIPTION
This PR removes all references to the `IsrConfig.doAddDistortionModel` field, which is no longer  used by `IsrTask`.